### PR TITLE
Update ca_certificate config to store path of ca-certificates.crt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -142,7 +142,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Proxy configuration
   if Vagrant.has_plugin?('vagrant-ca-certificates') and not config_file['ca_certificates'].nil?
     config.ca_certificates.enabled = true
-    config.ca_certificates.certs = Dir.glob(config_file['ca_certificates'])
+    config.ca_certificates.certs = Dir.glob(config_file['ca_certificates']['ca_certs_glob'])
+    config.vm.box_download_ca_cert = config_file['ca_certificates']['ca_certs_file']
   end
 
   # Provisioning from files available in provision directory

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,7 +4,9 @@ box_cpu_max_exec_cap: "90"
 disksize: "40GB"
 ip_address: "192.168.1.100"
 host_network: ~ # If vagrant ask for a network device, you may define it's label here.
-ca_certificates: ~ # Set to a glob expression where CA certificates are stored (C:/Users/USER/.ca-certificates/{GFI*.crt,*.local.crt})
+ca_certificates:
+  ca_certs_file: ~ # Path where ca-certificates.crt is stored (C:/Users/USER/ca-certificates.crt)
+  ca_certs_glob: ~ # Set to a glob expression where CA certificates are stored (C:/Users/USER/.ca-certificates/{GFI*.crt,*.local.crt})
 #ssh:
   #username: vagrant
 synced_folders:


### PR DESCRIPTION
Update ca_certificate config to store path of ca-certificates.crt for vagrant box_download_ca_cert.
Update of vagrantfile according to new yml config structure.