### PR TITLE
Fix docker compose version

### DIFF
--- a/provision/21-docker-compose.sh
+++ b/provision/21-docker-compose.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-DOCKER_COMPOSE_VERSION=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | grep 'tag_name' | cut -d\" -f4)
+DOCKER_COMPOSE_VERSION="1.29.2"
 docker-compose --version | grep "docker-compose version $DOCKER_COMPOSE_VERSION"
 VERSION_MATCH=$?
 if [ "$VERSION_MATCH" != "0" ]; then


### PR DESCRIPTION
Since new v2 release for docker compse, we have to change the install process. For now and BC, just fix the version.